### PR TITLE
Handle caller paths better when binaries are built with -trimpath option

### DIFF
--- a/default.go
+++ b/default.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime/debug"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Code-Hex/dd"
@@ -86,10 +88,20 @@ func defaultLevelEncoder(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
 }
 
 func defaultCallerEncoder(caller zapcore.EntryCaller, enc zapcore.PrimitiveArrayEncoder) {
+	callerFullPath := caller.FullPath()
+
 	var str string
 	if cwd, err := os.Getwd(); err == nil {
-		if rel, _ := filepath.Rel(cwd, caller.FullPath()); err == nil {
+		if rel, err := filepath.Rel(cwd, callerFullPath); err == nil {
 			str = rel
+		}
+	}
+	if str == "" {
+		// may have been built with -trimpath which will cause paths to be package paths instead of file paths
+		// try trimming the main module path else this will fall back to the full path
+		str = callerFullPath
+		if buildInfo, ok := debug.ReadBuildInfo(); ok {
+			str = strings.TrimPrefix(str, buildInfo.Main.Path+"/")
 		}
 	}
 


### PR DESCRIPTION
When binaries are built with `-trimpath` specified the caller path changes to the package path rather than a filesystem path triggering a bug in the existing code that results in an empty string being used.

This change fixes that bug so if all else fails the full package path will be returned or in the happy path if the caller is within a package contained under the main module it will remove the main module prefix.