### PR TITLE
Nicer support errors.Join from stdlib

### DIFF
--- a/error_unwrap_120.go
+++ b/error_unwrap_120.go
@@ -1,0 +1,55 @@
+//go:build go1.20
+
+package prettyconsole
+
+import (
+	"errors"
+	"reflect"
+	"strconv"
+)
+
+func writeError(enc *prettyConsoleEncoder, err error) (bool, error) {
+	// Write causes recursively
+	skipDetail := false
+	switch et := err.(type) {
+	case interface{ Cause() error }:
+		enc.addSafeString(err.Error())
+		if err := enc.encodeError("cause", et.Cause()); err != nil {
+			return skipDetail, err
+		}
+		skipDetail = true
+
+	case interface{ Errors() []error }:
+		enc.addSafeString(err.Error())
+		for i, ei := range et.Errors() {
+			if err := enc.encodeError("cause."+strconv.Itoa(i), ei); err != nil {
+				return skipDetail, err
+			}
+			skipDetail = true
+		}
+
+	case interface{ Unwrap() []error }:
+		if reflect.TypeOf(err) != joinErrorType {
+			// Special case the joinError type from the errors package, since its message is just the
+			// concatenation of its children separated by newlines (not something nicer like ':').
+			// Other notable types that implement this include fmt.Errorf with >1 %w verbs; however,
+			// because the message could contain other pertinent information, we don't want to skip.
+			enc.addSafeString(err.Error())
+		}
+		for i, ei := range et.Unwrap() {
+			if err := enc.encodeError(strconv.Itoa(i), ei); err != nil {
+				return skipDetail, err
+			}
+			skipDetail = true
+		}
+
+	default:
+		enc.addSafeString(err.Error())
+	}
+	return skipDetail, nil
+}
+
+// joinErrorType is the reflect.Type of the joinError type from the errors package. Because it's a private struct,
+// we have to use reflect on the result of the function to check for it. `Join` on 0-1 non-nil errors won't give this struct,
+// so use 2 arbitrary non-nil errors to get it.
+var joinErrorType = reflect.TypeOf(errors.Join(errors.ErrUnsupported, errors.ErrUnsupported))

--- a/error_unwrap_old.go
+++ b/error_unwrap_old.go
@@ -1,0 +1,28 @@
+//go:build !go1.20
+
+package prettyconsole
+
+import "strconv"
+
+func writeError(enc *prettyConsoleEncoder, err error) (bool, error) {
+	basic := err.Error()
+	enc.addSafeString(basic)
+
+	skipDetail := false
+	switch et := err.(type) {
+	case interface{ Cause() error }:
+		if err := enc.encodeError("cause", et.Cause()); err != nil {
+			return skipDetail, err
+		}
+		skipDetail = true
+
+	case interface{ Errors() []error }:
+		for i, ei := range et.Errors() {
+			if err := enc.encodeError("cause."+strconv.Itoa(i), ei); err != nil {
+				return skipDetail, err
+			}
+			skipDetail = true
+		}
+	}
+	return skipDetail, nil
+}

--- a/internal/example_120_test.go
+++ b/internal/example_120_test.go
@@ -1,0 +1,27 @@
+//go:build go1.20
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	prettyconsole "github.com/thessem/zap-prettyconsole"
+	"go.uber.org/zap"
+)
+
+func TestGoErrors(t *testing.T) {
+	logger := prettyconsole.NewLogger(zap.DebugLevel)
+	joinedErr := errors.Join(
+		errors.New("1/2 things went wrong"),
+		errors.New("2/2 things went wrong"),
+	)
+	logger.Error("only joined error", zap.Error(joinedErr))
+
+	fmtErr := fmt.Errorf("two errors: %w and %w", errors.New("first error"), errors.New("second error"))
+	logger.Error("fmt errors", zap.Error(fmtErr))
+
+	fmtAndJoinedErr := fmt.Errorf("two errors: %w and %w", joinedErr, fmtErr)
+	logger.Error("fmt and joined errors", zap.Error(fmtAndJoinedErr))
+}


### PR DESCRIPTION
Also some handling for `fmt.Errorf` using multiple `%w` verbs.

![image](https://github.com/thessem/zap-prettyconsole/assets/90645437/4d8938a1-b4e4-4523-a6f9-d80a25253692)
