### PR TITLE
fix: avoid panics when Unwrap/Cause return nil.

### DIFF
--- a/error.go
+++ b/error.go
@@ -61,15 +61,15 @@ func (e *prettyConsoleEncoder) encodeError(key string, err error) (retErr error)
 	case interface{ Unwrap() []error }:
 		causes = et.Unwrap()
 	case interface{ Cause() error }:
-	  cause := et.Cause()
-	  if cause != nil {
-	    causes = []error{cause}
-	  }
+		cause := et.Cause()
+		if cause != nil {
+			causes = []error{cause}
+		}
 	case interface{ Unwrap() error }:
-	  cause := et.Unwrap()
-	  if cause != nil {
-	    causes = []error{cause}
-	  }
+		cause := et.Unwrap()
+		if cause != nil {
+			causes = []error{cause}
+		}
 	}
 
 	basic := err.Error()

--- a/error.go
+++ b/error.go
@@ -61,9 +61,15 @@ func (e *prettyConsoleEncoder) encodeError(key string, err error) (retErr error)
 	case interface{ Unwrap() []error }:
 		causes = et.Unwrap()
 	case interface{ Cause() error }:
-		causes = []error{et.Cause()}
+	  cause := et.Cause()
+	  if cause != nil {
+	    causes = []error{cause}
+	  }
 	case interface{ Unwrap() error }:
-		causes = []error{et.Unwrap()}
+	  cause := et.Unwrap()
+	  if cause != nil {
+	    causes = []error{cause}
+	  }
 	}
 
 	basic := err.Error()


### PR DESCRIPTION
The std lib's error package says that Unwrap may return nil when the error doesn't wrap another error; I'm assuming Cause works the same.

This change fixes a code path where a nil cause was being de-referenced and causing a "PANIC_DISPLAYING_ERROR" error to be printed instead of the error we're interested in.