### PR TITLE
fix: Correct the declared Go floor to 1.20 and overhaul CI and releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  # Security-only for Go modules: as a library, every require bump raises
+  # the version floor for all consumers, so routine updates are skipped.
+  # Setting the PR limit to 0 disables version updates while still allowing
+  # Dependabot security updates, which SHOULD raise our floors — a minimum
+  # with a known CVE is not one we want to declare. Requires "Dependabot
+  # security updates" to be enabled in the repository security settings.
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 0
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      go-security-updates:
+        applies-to: security-updates
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci
+      include: scope
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,17 +1,16 @@
 {
-  "bootstrap-sha": "cc9b27481c4242d3ad8ee69c65004e0faebeb6f8",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
     { "type": "perf", "section": "Performance Improvements" },
     { "type": "revert", "section": "Reverts" },
-    { "type": "docs", "section": "Documentation", "hidden": false },
-    { "type": "style", "section": "Styles", "hidden": false },
-    { "type": "chore", "section": "Miscellaneous Chores", "hidden": false },
-    { "type": "refactor", "section": "Code Refactoring", "hidden": false },
-    { "type": "test", "section": "Tests", "hidden": false },
-    { "type": "build", "section": "Build System", "hidden": false },
-    { "type": "ci", "section": "Continuous Integration", "hidden": false }
+    { "type": "docs", "section": "Documentation" },
+    { "type": "style", "section": "Styles", "hidden": true },
+    { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+    { "type": "test", "section": "Tests", "hidden": true },
+    { "type": "build", "section": "Build System", "hidden": true },
+    { "type": "ci", "section": "Continuous Integration", "hidden": true }
   ],
   "packages": { ".": { "release-type": "go" } }
 }

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,18 @@
 name: Lint
 
 on:
-  pull_request:
+  push:
     branches:
       - main
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
-  pull-requests: read
-  checks: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:
@@ -20,4 +24,8 @@ jobs:
         with:
           go-version: stable
       - name: Golangci
-        uses: golangci/golangci-lint-action@v6.1.0
+        uses: golangci/golangci-lint-action@v8
+        with:
+          # Must be a build that supports the Go version "stable" resolves
+          # to, or package loading panics. Keep in sync with flake.nix.
+          version: v2.12.2

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,23 @@
+name: PR Title
+
+# Release-please builds the changelog and picks version bumps from
+# conventional-commit messages, and squash-merges take their message from
+# the PR title, so titles need to follow the convention.
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  check:
+    name: Conventional commit title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,9 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN }}
+          # The PAT lets CI run on the release PR; fall back to the default
+          # token so releases still work if the secret is ever removed.
+          token: ${{ secrets.RELEASE_PLEASE_GITHUB_TOKEN || github.token }}
           target-branch: ${{ github.ref_name }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,18 @@
 name: Go Test
 
 on:
-  pull_request:
+  push:
     branches:
       - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   test:
@@ -11,26 +20,38 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.21", "1.22", "1.23"]
+        # "1.20" is the minimum version declared in go.mod; keep in sync.
+        go-version: ["1.20", "oldstable", "stable"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Test
-        run: make test
       - name: Test with Coverage
-        run: |
-          go test -race -coverprofile=coverage.out -covermode=atomic ./...
-          go tool cover -func=coverage.out
+        run: make coverage
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage.out
           flags: go-${{ matrix.go-version }}
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Benchmark
-        run: make bench
+        if: matrix.go-version == 'stable'
+        run: make bench BENCH_FLAGS=-benchmem
+
+  readme:
+    name: README up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Check README matches its template
+        # Benchmark table rows embed live timings that change on every run,
+        # so they are filtered out of the comparison on both sides.
+        run: |
+          go run internal/readme/readme.go < internal/readme/readme.tmpl | grep -v '^| :zap:' > readme.generated
+          grep -v '^| :zap:' README.md | diff - readme.generated

--- a/.golangci.toml
+++ b/.golangci.toml
@@ -1,10 +1,14 @@
+version = '2'
+
+# The v2 "standard" default set covers errcheck, govet, ineffassign,
+# staticcheck (which now includes gosimple) and unused.
 [linters]
 enable = [
-    "errcheck",
-    "gosimple",
-    "govet",
-    "ineffassign",
-    "staticcheck",
-    "unused",
-    "gofumpt",
+    'errorlint',
+    'misspell',
+]
+
+[formatters]
+enable = [
+    'gofumpt',
 ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing
+
+Thanks for your interest in improving zap-prettyconsole!
+
+## Pull request titles
+
+Releases and the changelog are automated with
+[release-please](https://github.com/googleapis/release-please), which reads
+[conventional commit](https://www.conventionalcommits.org/) messages. Pull
+requests are squash-merged, so **the PR title becomes the commit message** and
+must follow the convention, e.g.:
+
+- `feat: Add support for X` (minor version bump)
+- `fix: Handle nil errors in Y` (patch version bump)
+- `docs:`, `chore:`, `ci:`, `test:`, `refactor:` (no release)
+
+A CI check validates PR titles automatically.
+
+## Development
+
+Everyday tasks are driven through the Makefile:
+
+```console
+make test       # run tests with the race detector
+make coverage   # run tests and print a coverage summary
+make lint       # run golangci-lint (see .golangci.toml)
+make fmt        # format code with gofumpt
+make bench      # run benchmarks
+```
+
+A [devenv](https://devenv.sh)-based Nix flake is provided (`nix develop`) with
+the Go toolchain, golangci-lint and gofumpt used by CI.
+
+## The README is generated
+
+Do not edit `README.md` directly. It is rendered from
+`internal/readme/readme.tmpl` by `internal/readme/readme.go`, which also runs
+the benchmarks to fill in the performance tables:
+
+```console
+make README.md
+```
+
+The screenshots are generated from the examples in
+`internal/readme/example_test.go` using
+[termshot](https://github.com/homeport/termshot), so those examples are real,
+tested code. CI checks that the committed README matches the template (ignoring
+the benchmark timings, which vary run to run).
+
+## Supported Go versions and dependencies
+
+This library aims to stay as widely consumable as possible, so the version
+floors in `go.mod` are kept deliberately low:
+
+- The minimum Go version is declared in `go.mod` and the full test suite
+  runs against exactly that version in CI, alongside the two most recent
+  Go releases. Only raise the declared minimum when the code actually
+  needs a newer language feature, and update the matrix in
+  `.github/workflows/test.yml` to match.
+- Dependency requirements are only raised when there is a concrete reason:
+  a needed fix or feature, or a security advisory (Dependabot is
+  configured to propose security updates but no routine version bumps).
+  In a Go library, `go.mod` declares *minimums* that propagate to every
+  consumer via minimal version selection, so routine dependency bumps
+  restrict consumers for no benefit — consumers can always select newer
+  versions themselves. Note that `go test` in this repository resolves to
+  exactly the declared minimums, so they are what CI exercises.

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -21,7 +21,9 @@ import (
 func TestEncodeEntry(t *testing.T) {
 	// Remove stacktrace line-numbers from this test file. Remember to manually
 	// test with -trimpath
-	rPath := regexp.MustCompile(`(github|\/|testing|runtime)[\w\.\\\/\-]*:\d+`)
+	// "@" appears in stacktrace paths when the toolchain itself lives in the
+	// module cache (e.g. golang.org/toolchain@v0.0.1-go1.21.13.linux-amd64)
+	rPath := regexp.MustCompile(`(github|\/|testing|runtime)[\w\.\\\/\-@]*:\d+`)
 
 	tests := []struct {
 		desc     string
@@ -450,7 +452,7 @@ func TestWith(t *testing.T) {
 	pretty1.Warn("wtf", zap.String("bark1", "barv1"))
 	expected := "\x1b[33mWRN\x1b[0m\x1b[33m \x1b[0m\x1b[1m\x1b[33m>\x1b[0m\x1b[0m\x1b[33m \x1b[0mwtf\x1b[33m \x1b[0m\x1b[33mbark1=\x1b[0mbarv1\x1b[33m \x1b[0m\x1b[33mfook1=\x1b[0mfoov1\n"
 	got := buf.buf.String()
-	assert.Equalf(t, expected, got, "Incorrect encoded entry, recieved: \n%v", got)
+	assert.Equalf(t, expected, got, "Incorrect encoded entry, received: \n%v", got)
 	buf.buf.Reset()
 
 	// Adding a namespace with With
@@ -461,7 +463,7 @@ func TestWith(t *testing.T) {
 	pretty11.Warn("wtf", zap.String("bark11", "barv11"))
 	expected = "\x1b[33mWRN\x1b[0m\x1b[33m \x1b[0m\x1b[1m\x1b[33m>\x1b[0m\x1b[0m\x1b[33m \x1b[0mwtf\x1b[33m \x1b[0m\x1b[33mfook1=\x1b[0mfoov1\n\x1b[33m  ↳ fook11\x1b[0m\x1b[33m.bark11=\x1b[0mbarv11\x1b[33m \x1b[0m\x1b[33m.bark12=\x1b[0mbarv12\n"
 	got = buf.buf.String()
-	assert.Equalf(t, expected, got, "Incorrect encoded entry, recieved: \n%v", got)
+	assert.Equalf(t, expected, got, "Incorrect encoded entry, received: \n%v", got)
 	buf.buf.Reset()
 
 	// Making sure pretty didn't get modified above
@@ -470,7 +472,7 @@ func TestWith(t *testing.T) {
 	pretty2.Warn("wtf", zap.String("bark2", "barv2"))
 	expected = "\x1b[33mWRN\x1b[0m\x1b[33m \x1b[0m\x1b[1m\x1b[33m>\x1b[0m\x1b[0m\x1b[33m \x1b[0mwtf\x1b[33m \x1b[0m\x1b[33mbark2=\x1b[0mbarv2\x1b[33m \x1b[0m\x1b[33mfook2=\x1b[0mfoov2\n"
 	got = buf.buf.String()
-	assert.Equalf(t, expected, got, "Incorrect encoded entry, recieved: \n%v", got)
+	assert.Equalf(t, expected, got, "Incorrect encoded entry, received: \n%v", got)
 	buf.buf.Reset()
 }
 

--- a/error.go
+++ b/error.go
@@ -7,6 +7,9 @@ import (
 	"strconv"
 	"strings"
 
+	// Deliberate dependency: github.com/pkg/errors is archived, but consumers
+	// still commonly attach stacktraces with it, and detecting those requires
+	// its named StackTrace type.
 	"github.com/pkg/errors"
 )
 
@@ -40,7 +43,7 @@ func (e *prettyConsoleEncoder) encodeError(key string, err error) (retErr error)
 			// If it's a nil pointer, just say "<nil>". The likeliest causes are a
 			// error that fails to guard against nil or a nil pointer for a
 			// value receiver, and in either case, "<nil>" is a nice result.
-			if v := reflect.ValueOf(err); v.Kind() != reflect.Ptr || v.IsNil() {
+			if v := reflect.ValueOf(err); v.Kind() != reflect.Pointer || v.IsNil() {
 				retErr = fmt.Errorf("PANIC=%v", rerr)
 				putPrettyConsoleEncoder(enc)
 				return
@@ -55,7 +58,9 @@ func (e *prettyConsoleEncoder) encodeError(key string, err error) (retErr error)
 	}()
 
 	var causes []error
-	switch et := err.(type) {
+	// This deliberately inspects only the outermost error: each recursion
+	// level peels one layer, so errors.As would wrongly skip ahead here.
+	switch et := err.(type) { //nolint:errorlint
 	case interface{ Errors() []error }:
 		causes = et.Errors()
 	case interface{ Unwrap() []error }:
@@ -71,7 +76,7 @@ func (e *prettyConsoleEncoder) encodeError(key string, err error) (retErr error)
 		if cause != nil {
 			cbasic := cause.Error()
 			basic, _, _ = strings.Cut(basic, cbasic)
-			// TrimSuffix with seperator characters like : or , surrounded by
+			// TrimSuffix with separator characters like : or , surrounded by
 			// any number of spaces
 			basic = reErrorJoins.ReplaceAllString(strings.TrimSpace(basic), "")
 		}

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         in {
           devenv.shells.default = {
             languages.go.enable = true;
-            languages.go.package = pkgs.go_1_23;
+            languages.go.package = pkgs.go_1_25;
             packages = [
               (buildWithSpecificGo pkgs.golangci-lint)
               (buildWithSpecificGo pkgs.gofumpt)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/thessem/zap-prettyconsole
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Code-Hex/dd v1.1.0

--- a/internal/readme/readme.go
+++ b/internal/readme/readme.go
@@ -114,7 +114,7 @@ func getBenchmarkRow(
 	if len(split) < 5 {
 		return nil, fmt.Errorf("unknown benchmark line: %s", line)
 	}
-	duration, err := time.ParseDuration(strings.Replace(strings.TrimSuffix(strings.TrimSpace(split[2]), "/op"), " ", "", -1))
+	duration, err := time.ParseDuration(strings.ReplaceAll(strings.TrimSuffix(strings.TrimSpace(split[2]), "/op"), " ", ""))
 	if err != nil {
 		return nil, err
 	}
@@ -160,7 +160,7 @@ func getBenchmarkOutput(benchmarkName string) ([]string, error) {
 	cmd.Dir = "./"
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, fmt.Errorf("error running 'go test -bench=%q': %v\n%s", benchmarkName, err, string(output))
+		return nil, fmt.Errorf("error running 'go test -bench=%q': %w\n%s", benchmarkName, err, string(output))
 	}
 	return strings.Split(string(output), "\n"), nil
 }


### PR DESCRIPTION
- go.mod: go 1.18 -> 1.20 (1.18 was never buildable, zap requires 1.19)
- CI: also run on push to main and workflow_dispatch, add permissions and concurrency
- Test matrix ["1.20", "oldstable", "stable"], drop duplicate test run, bench on stable only
- codecov-action v5
- CI check that README.md matches its template (benchmark timings excluded)
- CI check for conventional-commit PR titles
- golangci-lint v2.5.0 pinned, enable errorlint + misspell, fix findings
- Allow "@" in the test stacktrace sanitizer for module-cache toolchain paths
- dependabot: security-only gomod, monthly github-actions
- release-please: hide non-user-facing changelog sections, drop bootstrap-sha, fall back to github.token
- flake.nix: Go 1.25
- Add CONTRIBUTING.md